### PR TITLE
fix: hide disability field from non admin users on inscription list

### DIFF
--- a/src/modules/inscripcion/SignupListTable.tsx
+++ b/src/modules/inscripcion/SignupListTable.tsx
@@ -75,8 +75,7 @@ export function SignupListTable(props: {
     'province',
     'city',
     'status',
-    'lastModifiedAt',
-    'disability'
+    'lastModifiedAt'
   ];
 
   const privateFields: SignupField[] = [
@@ -87,7 +86,8 @@ export function SignupListTable(props: {
     'helpWith',
     'food',
     'isCeliac',
-    'phoneNumber'
+    'phoneNumber',
+    'disability'
   ];
 
   const searchableFields: SignupField[] = [


### PR DESCRIPTION
### For regular user:
_Before:_
![image](https://github.com/BuenosCodes/etitango-front/assets/116025673/ef5e1889-197c-4421-8d61-954d78ef0a78)

_Details: disability field is now a private field_

_After:_
![image](https://github.com/BuenosCodes/etitango-front/assets/116025673/06717719-50dd-4842-9dad-679557c2208d)
